### PR TITLE
Update README.md to fix github clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note: you will need to have your Base Sepolia wallet private key in your env as 
 1. Clone the repository:
 
 ```sh
-git clone https://github.com/coinbase-samples/coinbase-samples/cdp-sdk-mass-payments-ts.git
+git clone https://github.com/coinbase-samples/cdp-sdk-mass-payments-ts.git
 cd cdp-sdk-mass-payments-ts
 ```
 


### PR DESCRIPTION
Typo found in the readme. Copy pasting the command leads to an error for the user:

remote: Not Found
fatal: repository 'https://github.com/coinbase-samples/coinbase-samples/cdp-sdk-mass-payments-ts.git/' not found